### PR TITLE
Ignore blacklist (issue #31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -726,6 +726,7 @@ You can customize how the scheduled traktarr is ran by editing the `traktarr.ser
   --no-search            Disable search when adding to Sonarr / Radarr.
   --run-now              Do a first run immediately without waiting.
   --no-notifications     Disable notifications.
+  --ignore-blacklist     Ignores the blacklist when running the command.
   --help                 Show this message and exit.
 ```
 
@@ -809,6 +810,7 @@ Options:
   -f, --folder TEXT         Add movies with this root folder to Radarr.
   --no-search               Disable search when adding movies to Radarr.
   --notifications           Send notifications.
+  --ignore-blacklist        Ignores the blacklist when running the command.
   --authenticate-user TEXT  Specify which user to authenticate with to
                             retrieve Trakt lists. Default: first user in the
                             config.
@@ -861,6 +863,7 @@ Options:
   -f, --folder TEXT         Add shows with this root folder to Sonarr.
   --no-search               Disable search when adding shows to Sonarr.
   --notifications           Send notifications.
+  --ignore-blacklist        Ignores the blacklist when running the command.
   --authenticate-user TEXT  Specify which user to authenticate with to
                             retrieve Trakt lists. Default: first user in the
                             config

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ You can repeat this process for as many users as you like.
   },
   "filters": {
     "movies": {
+      "disabled_for": [],
       "allowed_countries": [
         "us",
         "gb",
@@ -215,6 +216,7 @@ You can repeat this process for as many users as you like.
       "blacklisted_tmdb_ids": []
     },
     "shows": {
+      "disabled_for": [],
       "allowed_countries": [
         "us",
         "gb",
@@ -444,6 +446,7 @@ Use filters to specify the movie/shows's country of origin or blacklist (i.e. fi
 
 ```json
   "movies": {
+    "disabled_for": [],
     "allowed_countries": [
       "us",
       "gb",
@@ -464,6 +467,18 @@ Use filters to specify the movie/shows's country of origin or blacklist (i.e. fi
     "blacklisted_min_year": 2000,
     "blacklisted_tmdb_ids": []
   },
+```
+
+`disabled_for` - specify for which lists the blacklist must be disabled when running in automatic mode
+
+Example:
+
+```
+    "disabled_for": [
+        "anticipated",
+        "watchlist:user1",
+        "list:http://url-to-list"
+    ],
 ```
 
 `allowed_countries` - only add movies from these countries.
@@ -528,6 +543,18 @@ Use filters to specify the movie/shows's country of origin or blacklist (i.e. fi
   ],
   "blacklisted_tvdb_ids": []
 }
+```
+
+`disabled_for` - specify for which lists the blacklist must be disabled when running in automatic mode
+
+Example:
+
+```
+    "disabled_for": [
+        "anticipated",
+        "watchlist:user1",
+        "list:http://url-to-list"
+    ],
 ```
 
 `allowed_countries` - only add shows from these countries.

--- a/helpers/trakt.py
+++ b/helpers/trakt.py
@@ -106,7 +106,10 @@ def blacklisted_show_id(show, blacklisted_ids):
     return blacklisted
 
 
-def is_show_blacklisted(show, blacklist_settings):
+def is_show_blacklisted(show, blacklist_settings, ignore_blacklist):
+    if ignore_blacklist:
+        return False
+
     blacklisted = False
     try:
         if blacklisted_show_year(show, blacklist_settings.blacklisted_min_year,
@@ -228,7 +231,10 @@ def blacklisted_movie_id(movie, blacklisted_ids):
     return blacklisted
 
 
-def is_movie_blacklisted(movie, blacklist_settings):
+def is_movie_blacklisted(movie, blacklist_settings, ignore_blacklist):
+    if ignore_blacklist:
+        return False
+
     blacklisted = False
     try:
         if blacklisted_movie_title(movie, blacklist_settings.blacklist_title_keywords):

--- a/misc/config.py
+++ b/misc/config.py
@@ -57,6 +57,7 @@ class Config(object, metaclass=Singleton):
         },
         'filters': {
             'shows': {
+                'disabled_for': [],
                 'blacklisted_genres': [],
                 'blacklisted_networks': [],
                 'allowed_countries': [],
@@ -67,6 +68,7 @@ class Config(object, metaclass=Singleton):
                 'blacklisted_tvdb_ids': [],
             },
             'movies': {
+                'disabled_for': [],
                 'blacklisted_genres': [],
                 'blacklisted_min_runtime': 60,
                 'blacklisted_min_year': 2000,

--- a/traktarr.py
+++ b/traktarr.py
@@ -523,10 +523,15 @@ def automatic_shows(add_delay=2.5, no_search=False, notifications=False, ignore_
                 else:
                     log.info("Adding %d shows from Trakt's %s list", limit, list_type)
 
+                local_ignore_blacklist = ignore_blacklist
+
+                if list_type.lower() in cfg.filters.shows.disabled_for:
+                    local_ignore_blacklist = True
+
                 # run shows
                 added_shows = shows.callback(list_type=list_type, add_limit=limit,
                                              add_delay=add_delay, no_search=no_search,
-                                             notifications=notifications, ignore_blacklist=ignore_blacklist)
+                                             notifications=notifications, ignore_blacklist=local_ignore_blacklist)
             elif list_type.lower() == 'watchlist':
                 for authenticate_user, limit in value.items():
                     if limit <= 0:
@@ -535,11 +540,16 @@ def automatic_shows(add_delay=2.5, no_search=False, notifications=False, ignore_
                     else:
                         log.info("Adding %d shows from the %s from %s", limit, list_type, authenticate_user)
 
+                    local_ignore_blacklist = ignore_blacklist
+
+                    if "watchlist:%s".format(authenticate_user) in cfg.filters.shows.disabled_for:
+                        local_ignore_blacklist = True
+
                     # run shows
                     added_shows = shows.callback(list_type=list_type, add_limit=limit,
                                                  add_delay=add_delay, no_search=no_search,
                                                  notifications=notifications, authenticate_user=authenticate_user,
-                                                 ignore_blacklist=ignore_blacklist)
+                                                 ignore_blacklist=local_ignore_blacklist)
             elif list_type.lower() == 'lists':
                 for list, v in value.items():
                     if isinstance(v, dict):
@@ -549,11 +559,16 @@ def automatic_shows(add_delay=2.5, no_search=False, notifications=False, ignore_
                         authenticate_user = None
                         limit = v
 
+                    local_ignore_blacklist = ignore_blacklist
+
+                    if "list:%s".format(list) in cfg.filters.shows.disabled_for:
+                        local_ignore_blacklist = True
+
                     # run shows
                     added_shows = shows.callback(list_type=list, add_limit=limit,
                                                  add_delay=add_delay, no_search=no_search,
                                                  notifications=notifications, authenticate_user=authenticate_user,
-                                                 ignore_blacklist=ignore_blacklist)
+                                                 ignore_blacklist=local_ignore_blacklist)
 
             if added_shows is None:
                 log.error("Failed adding shows from Trakt's %s list", list_type)
@@ -596,10 +611,15 @@ def automatic_movies(add_delay=2.5, no_search=False, notifications=False, ignore
                 else:
                     log.info("Adding %d movies from Trakt's %s list", limit, list_type)
 
+                local_ignore_blacklist = ignore_blacklist
+
+                if list_type.lower() in cfg.filters.movies.disabled_for:
+                    local_ignore_blacklist = True
+
                 # run movies
                 added_movies = movies.callback(list_type=list_type, add_limit=limit,
                                                add_delay=add_delay, no_search=no_search,
-                                               notifications=notifications, ignore_blacklist=ignore_blacklist)
+                                               notifications=notifications, ignore_blacklist=local_ignore_blacklist)
             elif list_type.lower() == 'watchlist':
                 for authenticate_user, limit in value.items():
                     if limit <= 0:
@@ -608,11 +628,16 @@ def automatic_movies(add_delay=2.5, no_search=False, notifications=False, ignore
                     else:
                         log.info("Adding %d movies from the %s from %s", limit, list_type, authenticate_user)
 
+                    local_ignore_blacklist = ignore_blacklist
+
+                    if "watchlist:%s".format(authenticate_user) in cfg.filters.movies.disabled_for:
+                        local_ignore_blacklist = True
+
                     # run movies
                     added_movies = movies.callback(list_type=list_type, add_limit=limit,
                                                    add_delay=add_delay, no_search=no_search,
                                                    notifications=notifications, authenticate_user=authenticate_user,
-                                                   ignore_blacklist=ignore_blacklist)
+                                                   ignore_blacklist=local_ignore_blacklist)
             elif list_type.lower() == 'lists':
                 for list, v in value.items():
                     if isinstance(v, dict):
@@ -622,11 +647,16 @@ def automatic_movies(add_delay=2.5, no_search=False, notifications=False, ignore
                         authenticate_user = None
                         limit = v
 
+                    local_ignore_blacklist = ignore_blacklist
+
+                    if "list:%s".format(list) in cfg.filters.movies.disabled_for:
+                        local_ignore_blacklist = True
+
                     # run shows
                     added_movies = movies.callback(list_type=list, add_limit=limit,
                                                    add_delay=add_delay, no_search=no_search,
                                                    notifications=notifications, authenticate_user=authenticate_user,
-                                                   ignore_blacklist=ignore_blacklist)
+                                                   ignore_blacklist=local_ignore_blacklist)
 
             if added_movies is None:
                 log.error("Failed adding movies from Trakt's %s list", list_type)


### PR DESCRIPTION
Adds the ability to add `--ingnore-blacklist` to the `movies`, `shows` or `run` command to ignore the blacklist all together when running the command.

Furthermore this PR adds the ability to specify when to ignore the blacklist in automatic mode. This can be done by adding the following to the `movies` or `shows` `filter` options: 

```
    "disabled_for": [
        "anticipated",
        "watchlist:user1",
        "list:http://url-to-list"
    ],
```

You can add any "default" list type, like `anticipated`, `boxoffice`, ... or any watchlist or public/private list.

Solves: #31 