### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ You can repeat this process for as many users as you like.
         "gb",
         "ca"
       ],
-			"allowed_languages": [],
+      "allowed_languages": [],
       "blacklist_title_keywords": [
         "untitled",
         "barbie",
@@ -220,7 +220,7 @@ You can repeat this process for as many users as you like.
         "gb",
         "ca"
       ],
-			"allowed_languages": [],
+      "allowed_languages": [],
       "blacklisted_genres": [
         "animation",
         "game-show",
@@ -449,7 +449,7 @@ Use filters to specify the movie/shows's country of origin or blacklist (i.e. fi
       "gb",
       "ca"
     ],
-		"allowed_languages": [],
+    "allowed_languages": [],
     "blacklist_title_keywords": [
       "untitled",
       "barbie"
@@ -494,7 +494,7 @@ Use filters to specify the movie/shows's country of origin or blacklist (i.e. fi
     "gb",
     "ca"
   ],
-	"allowed_languages": [],
+  "allowed_languages": [],
   "blacklisted_genres": [
     "animation",
     "game-show",

--- a/README.md
+++ b/README.md
@@ -607,7 +607,7 @@ Sonarr configuration.
 
 ### Tags
 
-Tags option within Traktarr allow Sonarr to add tags shows so that you may filter out certain keywords out of shows from certain television networks.
+Tags option allows Sonarr to assign tags to shows, from specific television networks, to filter in/out certain keywords.
 
 **Example:**
 
@@ -616,7 +616,7 @@ To show how tags work, we will create a tag `AMZN` and assign it to certain tele
 1. First, we will create a tag in Sonarr (Settings > Indexers > Restrictions).
 
    ```
-   Must contain: BluRay, Amazon, AMZN,
+   Must contain: BluRay, Amazon, AMZN
    Must not contain:
    Tags: AMZN
    ```

--- a/README.md
+++ b/README.md
@@ -1,30 +1,3 @@
-<!-- TOC depthFrom:1 depthTo:2 withLinks:1 updateOnSave:1 orderedList:0 -->
-
-- [traktarr](#traktarr)
-- [Demo](#demo)
-- [Requirements](#requirements)
-- [Installation](#installation)
-	- [1. Base Install](#1-base-install)
-	- [2. Create a Trakt Application](#2-create-a-trakt-application)
-	- [3. Authenticate User(s) (optional)](#3-authenticate-users-optional)
-- [Configuration](#configuration)
-	- [Sample Configuration](#sample-configuration)
-	- [Core](#core)
-	- [Automatic](#automatic)
-	- [Filters](#filters)
-	- [Notifications](#notifications)
-	- [Radarr](#radarr)
-	- [Sonarr](#sonarr)
-	- [Trakt](#trakt)
-- [Usage](#usage)
-	- [Automatic (Scheduled)](#automatic-scheduled)
-	- [Manual (CLI)](#manual-cli)
-	- [Examples (Manual)](#examples-manual)
-
-<!-- /TOC -->
-
----
-
 [![made-with-python](https://img.shields.io/badge/Made%20with-Python-blue.svg)](https://www.python.org/)
 [![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](https://github.com/l3uddz/traktarr/blob/master/LICENSE)
 [![Feature Requests](https://img.shields.io/badge/Requests-Feathub-blue.svg)](http://feathub.com/l3uddz/traktarr)
@@ -56,6 +29,53 @@ Types of Trakt lists supported:
   - Custom list(s)
 
 \* Support for multiple (authenticated) users.
+
+---
+
+<!-- TOC depthFrom:1 depthTo:6 withLinks:1 updateOnSave:1 orderedList:0 -->
+
+- [traktarr](#traktarr)
+- [Demo](#demo)
+- [Requirements](#requirements)
+- [Installation](#installation)
+	- [1. Base Install](#1-base-install)
+	- [2. Create a Trakt Application](#2-create-a-trakt-application)
+	- [3. Authenticate User(s) (optional)](#3-authenticate-users-optional)
+- [Configuration](#configuration)
+	- [Sample Configuration](#sample-configuration)
+	- [Core](#core)
+	- [Automatic](#automatic)
+		- [Personal Watchlists](#personal-watchlists)
+		- [Custom Lists](#custom-lists)
+			- [Public Lists](#public-lists)
+			- [Private Lists](#private-lists)
+	- [Filters](#filters)
+		- [Movies](#movies)
+		- [Shows](#shows)
+	- [Notifications](#notifications)
+		- [Pushover](#pushover)
+		- [Slack](#slack)
+	- [Radarr](#radarr)
+	- [Sonarr](#sonarr)
+		- [Tags](#tags)
+	- [Trakt](#trakt)
+- [Usage](#usage)
+	- [Automatic (Scheduled)](#automatic-scheduled)
+		- [Setup](#setup)
+		- [Customize](#customize)
+	- [Manual (CLI)](#manual-cli)
+		- [General](#general)
+		- [Movie (Single Movie)](#movie-single-movie)
+		- [Movies (Multiple Movies)](#movies-multiple-movies)
+		- [Show (Single Show)](#show-single-show)
+		- [Shows (Multiple Shows)](#shows-multiple-shows)
+	- [Examples (Manual)](#examples-manual)
+
+<!-- /TOC -->
+
+---
+
+
 
 
 # Demo

--- a/README.md
+++ b/README.md
@@ -259,7 +259,8 @@ You can repeat this process for as many users as you like.
     "pushover": {
       "service": "pushover",
       "app_token": "",
-      "user_token": ""
+      "user_token": "",
+      "priority": 0
     },
     "slack": {
       "service": "slack",
@@ -564,7 +565,8 @@ Currently, only Pushover and Slack are supported. More will be added later.
   "pushover": {
     "service": "pushover",
     "app_token": "",
-    "user_token": ""
+    "user_token": "",
+    "priority": 0
   },
   "slack": {
     "service": "slack",
@@ -581,6 +583,8 @@ Currently, only Pushover and Slack are supported. More will be added later.
 ### Pushover
 
 `app_token` and `user_token` - retrieve from Pushover.net.
+
+You can specify a priority for the messages send via Pushover using the `priority` key. It can be any Pushover priority value (https://pushover.net/api#priority).
 
 _Note: The key name (i.e the name right under notifications) can be anything, but the `"service":` must be exactly `"pushover"`._
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ You can repeat this process for as many users as you like.
         "gb",
         "ca"
       ],
+			"allowed_languages": [],
       "blacklist_title_keywords": [
         "untitled",
         "barbie",
@@ -199,6 +200,7 @@ You can repeat this process for as many users as you like.
         "gb",
         "ca"
       ],
+			"allowed_languages": [],
       "blacklisted_genres": [
         "animation",
         "game-show",
@@ -427,6 +429,7 @@ Use filters to specify the movie/shows's country of origin or blacklist (i.e. fi
       "gb",
       "ca"
     ],
+		"allowed_languages": [],
     "blacklist_title_keywords": [
       "untitled",
       "barbie"
@@ -443,7 +446,12 @@ Use filters to specify the movie/shows's country of origin or blacklist (i.e. fi
   },
 ```
 
-`allowed_countries` - allowed countries of origin.
+`allowed_countries` - only add movies from these countries.
+
+`allowed_languages` - only add movies with these languages (default/blank=English).
+
+- By default, traktarr will only query shows in English. If you need to search for other languages (e.g. Japanese for anime), you must add those languages here.
+- Languages are in [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1) format (e.g. `ja` for Japanese.)
 
 `blacklist_title_keywords` - blacklist certain words in titles.
 
@@ -466,6 +474,7 @@ Use filters to specify the movie/shows's country of origin or blacklist (i.e. fi
     "gb",
     "ca"
   ],
+	"allowed_languages": [],
   "blacklisted_genres": [
     "animation",
     "game-show",
@@ -501,7 +510,12 @@ Use filters to specify the movie/shows's country of origin or blacklist (i.e. fi
 }
 ```
 
-`allowed_countries` - allowed countries of origin.
+`allowed_countries` - only add shows from these countries.
+
+`allowed_languages` - only add shows with these languages (default/blank=English).
+
+- By default, traktarr will only query shows in English. If you need to search for other languages (e.g. Japanese for anime), you must add those languages here.
+- Languages are in [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1) format (e.g. `ja` for Japanese.)
 
 `blacklisted_genres` - blacklist certain genres.
 

--- a/README.md
+++ b/README.md
@@ -375,45 +375,45 @@ Private lists can be added in two ways:
 
 1. If there is only one authenticated user, you can add the private list just like any other public list:
 
-```json
-"automatic": {
-  "movies": {
-    "lists": {
-        "https://trakt.tv/users/user/lists/my-private-movies-list": 10
-    }
-  },
-  "shows": {
-    "lists": {
-        "https://trakt.tv/users/user/lists/my-private-shows-list": 10
-    }
-  }
-},
-```
+   ```json
+   "automatic": {
+     "movies": {
+       "lists": {
+           "https://trakt.tv/users/user/lists/my-private-movies-list": 10
+       }
+     },
+     "shows": {
+       "lists": {
+           "https://trakt.tv/users/user/lists/my-private-shows-list": 10
+       }
+     }
+   },
+   ```
 
 2. If there are multiple authenticated users you want to fetch the lists from, you'll need to specify the username under `authenticate_as`.
 
-_Note: The user should have access to the list (either own the list or a list that was shared to them by a friend)._
+   _Note: The user should have access to the list (either own the list or a list that was shared to them by a friend)._
 
-```json
-"automatic": {
-  "movies": {
-    "lists": {
-        "https://trakt.tv/users/user/lists/my-private-movies-list": {
-            "authenticate_as": "user2",
-            "limit": 10
-        }
-    }
-  },
-  "shows": {
-    "lists": {
-        "https://trakt.tv/users/user/lists/my-private-shows-list": {
-            "authenticate_as": "user2",
-            "limit": 10
-        }
-    }
-  }
-},
-```
+   ```json
+   "automatic": {
+     "movies": {
+       "lists": {
+           "https://trakt.tv/users/user/lists/my-private-movies-list": {
+               "authenticate_as": "user2",
+               "limit": 10
+           }
+       }
+     },
+     "shows": {
+       "lists": {
+           "https://trakt.tv/users/user/lists/my-private-shows-list": {
+               "authenticate_as": "user2",
+               "limit": 10
+           }
+       }
+     }
+   },
+   ```
 
 
 ## Filters

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ You can repeat this process for as many users as you like.
   },
   "filters": {
     "movies": {
+      "disabled_for": [],
       "allowed_countries": [
         "us",
         "gb",
@@ -215,6 +216,7 @@ You can repeat this process for as many users as you like.
       "blacklisted_tmdb_ids": []
     },
     "shows": {
+      "disabled_for": [],
       "allowed_countries": [
         "us",
         "gb",
@@ -445,6 +447,7 @@ Use filters to specify the movie/shows's country of origin or blacklist (i.e. fi
 
 ```json
   "movies": {
+    "disabled_for": [],
     "allowed_countries": [
       "us",
       "gb",
@@ -465,6 +468,18 @@ Use filters to specify the movie/shows's country of origin or blacklist (i.e. fi
     "blacklisted_min_year": 2000,
     "blacklisted_tmdb_ids": []
   },
+```
+
+`disabled_for` - specify for which lists the blacklist must be disabled when running in automatic mode
+
+Example:
+
+```
+    "disabled_for": [
+        "anticipated",
+        "watchlist:user1",
+        "list:http://url-to-list"
+    ],
 ```
 
 `allowed_countries` - only add movies from these countries.
@@ -529,6 +544,18 @@ Use filters to specify the movie/shows's country of origin or blacklist (i.e. fi
   ],
   "blacklisted_tvdb_ids": []
 }
+```
+
+`disabled_for` - specify for which lists the blacklist must be disabled when running in automatic mode
+
+Example:
+
+```
+    "disabled_for": [
+        "anticipated",
+        "watchlist:user1",
+        "list:http://url-to-list"
+    ],
 ```
 
 `allowed_countries` - only add shows from these countries.
@@ -730,6 +757,7 @@ You can customize how the scheduled traktarr is ran by editing the `traktarr.ser
   --no-search            Disable search when adding to Sonarr / Radarr.
   --run-now              Do a first run immediately without waiting.
   --no-notifications     Disable notifications.
+  --ignore-blacklist     Ignores the blacklist when running the command.
   --help                 Show this message and exit.
 ```
 
@@ -813,6 +841,7 @@ Options:
   -f, --folder TEXT         Add movies with this root folder to Radarr.
   --no-search               Disable search when adding movies to Radarr.
   --notifications           Send notifications.
+  --ignore-blacklist        Ignores the blacklist when running the command.
   --authenticate-user TEXT  Specify which user to authenticate with to
                             retrieve Trakt lists. Default: first user in the
                             config.
@@ -865,6 +894,7 @@ Options:
   -f, --folder TEXT         Add shows with this root folder to Sonarr.
   --no-search               Disable search when adding shows to Sonarr.
   --notifications           Send notifications.
+  --ignore-blacklist        Ignores the blacklist when running the command.
   --authenticate-user TEXT  Specify which user to authenticate with to
                             retrieve Trakt lists. Default: first user in the
                             config

--- a/README.md
+++ b/README.md
@@ -607,7 +607,7 @@ Sonarr configuration.
 
 ### Tags
 
-Tags option allows Sonarr to assign tags to shows, from specific television networks, to filter in/out certain keywords.
+The `tags` option allows Sonarr to assign tags to shows from specific television networks, so that Sonarr can filter in/out certain keywords from releases.
 
 **Example:**
 

--- a/README.md
+++ b/README.md
@@ -749,11 +749,7 @@ Options:
   --help                Show this message and exit.
 ```
 
-<<<<<<< HEAD
-_Note: This command only works with `-id` or `--show_id` specified (i.e. not with lists), and support both Trakt IDs and IMDB IDs._
-=======
 _Note: This command only works with `-id` or `--show_id` specified (i.e. not with lists), and supports both Trakt IDs and IMDB IDs._
->>>>>>> Readme: minor fixes
 
 ### Movies (Multiple Movies)
 
@@ -804,11 +800,7 @@ Options:
   --help               Show this message and exit.
 ```
 
-<<<<<<< HEAD
-_Note: This command only works with `-id` or `--show_id` specified (i.e. not with lists), and support both Trakt IDs and IMDB IDs._
-=======
 _Note: This command only works with `-id` or `--show_id` specified (i.e. not with lists), and supports both Trakt IDs and IMDB IDs._
->>>>>>> Readme: minor fixes
 
 
 ### Shows (Multiple Shows)

--- a/helpers/misc.py
+++ b/helpers/misc.py
@@ -77,3 +77,8 @@ def sorted_list(original_list, list_type, sort_key, reverse=True):
                 item[list_type][sort_key] = 0
 
     return sorted(prepared_list, key=lambda k: k[list_type][sort_key], reverse=reverse)
+
+
+# reference: https://stackoverflow.com/a/16712886
+def substring_after(s, delim):
+    return s.partition(delim)[2]

--- a/helpers/misc.py
+++ b/helpers/misc.py
@@ -44,3 +44,22 @@ def dict_merge(dct, merge_dct):
             dct[k] = merge_dct[k]
 
     return dct
+
+
+def unblacklist_genres(genre, blacklisted_genres):
+    genres = genre.split(',')
+    for allow_genre in genres:
+        if allow_genre in blacklisted_genres:
+            blacklisted_genres.remove(allow_genre)
+    return
+
+
+def allowed_genres(genre, object_type, trakt_object):
+    allowed_object = False
+    genres = genre.split(',')
+
+    for item in genres:
+        if item.lower() in trakt_object[object_type]['genres']:
+            allowed_object = True
+            break
+    return allowed_object

--- a/helpers/misc.py
+++ b/helpers/misc.py
@@ -1,3 +1,5 @@
+from copy import copy
+
 from misc.log import logger
 
 log = logger.get_logger(__name__)
@@ -63,3 +65,15 @@ def allowed_genres(genre, object_type, trakt_object):
             allowed_object = True
             break
     return allowed_object
+
+
+def sorted_list(original_list, list_type, sort_key, reverse=True):
+    prepared_list = copy(original_list)
+    for item in prepared_list:
+        if not item[list_type][sort_key]:
+            if sort_key == 'released' or sort_key == 'first_aired':
+                item[list_type][sort_key] = ""
+            else:
+                item[list_type][sort_key] = 0
+
+    return sorted(prepared_list, key=lambda k: k[list_type][sort_key], reverse=reverse)

--- a/helpers/trakt.py
+++ b/helpers/trakt.py
@@ -106,7 +106,10 @@ def blacklisted_show_id(show, blacklisted_ids):
     return blacklisted
 
 
-def is_show_blacklisted(show, blacklist_settings):
+def is_show_blacklisted(show, blacklist_settings, ignore_blacklist):
+    if ignore_blacklist:
+        return False
+
     blacklisted = False
     try:
         if blacklisted_show_year(show, blacklist_settings.blacklisted_min_year,
@@ -228,7 +231,10 @@ def blacklisted_movie_id(movie, blacklisted_ids):
     return blacklisted
 
 
-def is_movie_blacklisted(movie, blacklist_settings):
+def is_movie_blacklisted(movie, blacklist_settings, ignore_blacklist):
+    if ignore_blacklist:
+        return False
+
     blacklisted = False
     try:
         if blacklisted_movie_title(movie, blacklist_settings.blacklist_title_keywords):

--- a/media/trakt.py
+++ b/media/trakt.py
@@ -57,11 +57,14 @@ class Trakt:
 
     @backoff.on_predicate(backoff.expo, lambda x: x is None, max_tries=4, on_backoff=backoff_handler)
     def _make_items_request(self, url, limit, languages, type_name, object_name, authenticate_user=None, payload={},
-                            sleep_between=5):
-        if languages is None:
+                            sleep_between=5, genres=None):
+        if not languages:
             languages = ['en']
 
         payload = dict_merge(payload, {'extended': 'full', 'limit': limit, 'page': 1, 'languages': ','.join(languages)})
+        if genres:
+            payload['genres'] = genres
+
         processed = []
 
         type_name = type_name.replace('{authenticate_user}', self._user_used_for_authentication(authenticate_user))
@@ -81,7 +84,10 @@ class Trakt:
 
                     for item in resp_json:
                         if item not in processed:
-                            processed.append(item)
+                            if object_name.rstrip('s') not in item and 'title' in item:
+                                processed.append({object_name.rstrip('s'): item})
+                            else:
+                                processed.append(item)
 
                     # check if we have fetched the last page, break if so
                     if total_pages == 0:
@@ -306,31 +312,34 @@ class Trakt:
             object_name='show',
         )
 
-    def get_trending_shows(self, limit=1000, languages=None):
+    def get_trending_shows(self, limit=1000, languages=None, genres=None):
         return self._make_items_request(
             url='https://api.trakt.tv/shows/trending',
             limit=limit,
             languages=languages,
             object_name='shows',
             type_name='trending',
+            genres=genres
         )
 
-    def get_popular_shows(self, limit=1000, languages=None):
+    def get_popular_shows(self, limit=1000, languages=None, genres=None):
         return self._make_items_request(
             url='https://api.trakt.tv/shows/popular',
             limit=limit,
             languages=languages,
             object_name='shows',
             type_name='popular',
+            genres=genres
         )
 
-    def get_anticipated_shows(self, limit=1000, languages=None):
+    def get_anticipated_shows(self, limit=1000, languages=None, genres=None):
         return self._make_items_request(
             url='https://api.trakt.tv/shows/anticipated',
             limit=limit,
             languages=languages,
             object_name='shows',
             type_name='anticipated',
+            genres=genres
         )
 
     def get_watchlist_shows(self, authenticate_user=None, limit=1000, languages=None):
@@ -367,31 +376,34 @@ class Trakt:
             object_name='movie',
         )
 
-    def get_trending_movies(self, limit=1000, languages=None):
+    def get_trending_movies(self, limit=1000, languages=None, genres=None):
         return self._make_items_request(
             url='https://api.trakt.tv/movies/trending',
             limit=limit,
             languages=languages,
             object_name='movies',
             type_name='trending',
+            genres=genres
         )
 
-    def get_popular_movies(self, limit=1000, languages=None):
+    def get_popular_movies(self, limit=1000, languages=None, genres=None):
         return self._make_items_request(
             url='https://api.trakt.tv/movies/popular',
             limit=limit,
             languages=languages,
             object_name='movies',
             type_name='popular',
+            genres=genres
         )
 
-    def get_anticipated_movies(self, limit=1000, languages=None):
+    def get_anticipated_movies(self, limit=1000, languages=None, genres=None):
         return self._make_items_request(
             url='https://api.trakt.tv/movies/anticipated',
             limit=limit,
             languages=languages,
             object_name='movies',
             type_name='anticipated',
+            genres=genres
         )
 
     def get_boxoffice_movies(self, limit=1000, languages=None):

--- a/media/trakt.py
+++ b/media/trakt.py
@@ -11,7 +11,7 @@ log = logger.get_logger(__name__)
 
 
 class Trakt:
-    non_user_lists = ['anticipated', 'trending', 'popular', 'boxoffice']
+    non_user_lists = ['anticipated', 'trending', 'popular', 'boxoffice', 'watched', 'played']
 
     def __init__(self, cfg):
         self.cfg = cfg
@@ -343,6 +343,26 @@ class Trakt:
             genres=genres
         )
 
+    def get_most_played_shows(self, limit=1000, languages=None, genres=None, most_type=None):
+        return self._make_items_request(
+            url='https://api.trakt.tv/shows/played/%s' % ('weekly' if not most_type else most_type),
+            limit=limit,
+            languages=languages,
+            object_name='shows',
+            type_name='played',
+            genres=genres
+        )
+
+    def get_most_watched_shows(self, limit=1000, languages=None, genres=None, most_type=None):
+        return self._make_items_request(
+            url='https://api.trakt.tv/shows/watched/%s' % ('weekly' if not most_type else most_type),
+            limit=limit,
+            languages=languages,
+            object_name='shows',
+            type_name='watched',
+            genres=genres
+        )
+
     def get_watchlist_shows(self, authenticate_user=None, limit=1000, languages=None):
         return self._make_items_request(
             url='https://api.trakt.tv/users/{authenticate_user}/watchlist/shows',
@@ -404,6 +424,26 @@ class Trakt:
             languages=languages,
             object_name='movies',
             type_name='anticipated',
+            genres=genres
+        )
+
+    def get_most_played_movies(self, limit=1000, languages=None, genres=None, most_type=None):
+        return self._make_items_request(
+            url='https://api.trakt.tv/movies/played/%s' % ('weekly' if not most_type else most_type),
+            limit=limit,
+            languages=languages,
+            object_name='movies',
+            type_name='played',
+            genres=genres
+        )
+
+    def get_most_watched_movies(self, limit=1000, languages=None, genres=None, most_type=None):
+        return self._make_items_request(
+            url='https://api.trakt.tv/movies/watched/%s' % ('weekly' if not most_type else most_type),
+            limit=limit,
+            languages=languages,
+            object_name='movies',
+            type_name='watched',
             genres=genres
         )
 

--- a/media/trakt.py
+++ b/media/trakt.py
@@ -67,7 +67,8 @@ class Trakt:
 
         processed = []
 
-        type_name = type_name.replace('{authenticate_user}', self._user_used_for_authentication(authenticate_user))
+        if authenticate_user:
+            type_name = type_name.replace('{authenticate_user}', self._user_used_for_authentication(authenticate_user))
 
         try:
             while True:

--- a/misc/config.py
+++ b/misc/config.py
@@ -57,6 +57,7 @@ class Config(object, metaclass=Singleton):
         },
         'filters': {
             'shows': {
+                'disabled_for': [],
                 'blacklisted_genres': [],
                 'blacklisted_networks': [],
                 'allowed_countries': [],
@@ -67,6 +68,7 @@ class Config(object, metaclass=Singleton):
                 'blacklisted_tvdb_ids': [],
             },
             'movies': {
+                'disabled_for': [],
                 'blacklisted_genres': [],
                 'blacklisted_min_runtime': 60,
                 'blacklisted_min_year': 2000,

--- a/misc/config.py
+++ b/misc/config.py
@@ -60,6 +60,7 @@ class Config(object, metaclass=Singleton):
                 'blacklisted_genres': [],
                 'blacklisted_networks': [],
                 'allowed_countries': [],
+                'allowed_languages': [],
                 'blacklisted_min_runtime': 15,
                 'blacklisted_min_year': 2000,
                 'blacklisted_max_year': 2019,
@@ -72,7 +73,8 @@ class Config(object, metaclass=Singleton):
                 'blacklisted_max_year': 2019,
                 'blacklist_title_keywords': [],
                 'blacklisted_tmdb_ids': [],
-                'allowed_countries': []
+                'allowed_countries': [],
+                'allowed_languages': []
             }
         },
         'automatic': {
@@ -153,11 +155,6 @@ class Config(object, metaclass=Singleton):
     def __inner_upgrade(self, settings1, settings2, key=None, overwrite=False):
         sub_upgraded = False
         merged = settings2.copy()
-
-        # print(settings1)
-        # print(settings2)
-        # print(overwrite)
-        # print("_______________")
 
         if isinstance(settings1, dict):
             for k, v in settings1.items():

--- a/notifications/pushover.py
+++ b/notifications/pushover.py
@@ -8,9 +8,10 @@ log = logger.get_logger(__name__)
 class Pushover:
     NAME = "Pushover"
 
-    def __init__(self, app_token, user_token):
+    def __init__(self, app_token, user_token, priority=0):
         self.app_token = app_token
         self.user_token = user_token
+        self.priority = priority
         log.debug("Initialized Pushover notification agent")
 
     def send(self, **kwargs):
@@ -23,7 +24,8 @@ class Pushover:
             payload = {
                 'token': self.app_token,
                 'user': self.user_token,
-                'message': kwargs['message']
+                'message': kwargs['message'],
+                'priority': self.priority,
             }
             resp = requests.post('https://api.pushover.net/1/messages.json', data=payload, timeout=30)
             return True if resp.status_code == 200 else False

--- a/traktarr.py
+++ b/traktarr.py
@@ -2,6 +2,7 @@
 import os.path
 import sys
 import time
+import signal
 
 import click
 import schedule
@@ -701,13 +702,19 @@ def init_notifications():
     return
 
 
+# Handles exit signals, cancels jobs and exits cleanly
+def exit_handler(signum, frame):
+    log.info(f"Received {signal.Signals(signum).name}, canceling jobs and exiting.")
+    schedule.clear()
+    exit()
+
+
 ############################################################
 # MAIN
 ############################################################
 
 if __name__ == "__main__":
     print("""
-
   ,--.                 ,--.     ,--.
 ,-'  '-.,--.--. ,--,--.|  |,-.,-'  '-. ,--,--.,--.--.,--.--.
 '-.  .-'|  .--'' ,-.  ||     /'-.  .-'' ,-.  ||  .--'|  .--'
@@ -722,5 +729,11 @@ if __name__ == "__main__":
 #########################################################################
 # GNU General Public License v3.0                                       #
 #########################################################################
-        """)
+""")
+
+    # Register the signal handlers
+    signal.signal(signal.SIGTERM, exit_handler)
+    signal.signal(signal.SIGINT, exit_handler)
+
+    # Start application
     app()

--- a/traktarr.py
+++ b/traktarr.py
@@ -242,8 +242,8 @@ def shows(list_type, add_limit=0, add_delay=2.5, sort='votes', genre=None, folde
         log.error("Aborting due to failure to remove existing Sonarr shows from retrieved Trakt shows list")
         if notifications:
             callback_notify({'event': 'abort', 'type': 'shows', 'list_type': list_type,
-                             'reason': 'Failure to remove existing Sonarr shows from retrieved Trakt %s shows list' % list_type
-                             })
+                             'reason': 'Failure to remove existing Sonarr shows from retrieved Trakt %s shows list'
+                                       % list_type})
         return None
     else:
         log.info("Removed existing Sonarr shows from Trakt shows list, shows left to process: %d",

--- a/traktarr.py
+++ b/traktarr.py
@@ -17,7 +17,7 @@ notify = None
 
 # Click
 @click.group(help='Add new shows & movies to Sonarr/Radarr from Trakt.')
-@click.version_option('1.2.0', prog_name='traktarr')
+@click.version_option('1.2.1', prog_name='traktarr')
 @click.option(
     '--config',
     envvar='TRAKTARR_CONFIG',

--- a/traktarr.py
+++ b/traktarr.py
@@ -17,7 +17,7 @@ notify = None
 
 # Click
 @click.group(help='Add new shows & movies to Sonarr/Radarr from Trakt.')
-@click.version_option('1.2.1', prog_name='traktarr')
+@click.version_option('1.2.2', prog_name='traktarr')
 @click.option(
     '--config',
     envvar='TRAKTARR_CONFIG',

--- a/traktarr.py
+++ b/traktarr.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 import os.path
+import signal
 import sys
 import time
-import signal
 
 import click
 import schedule
@@ -706,7 +706,7 @@ def init_notifications():
 
 # Handles exit signals, cancels jobs and exits cleanly
 def exit_handler(signum, frame):
-    log.info(f"Received {signal.Signals(signum).name}, canceling jobs and exiting.")
+    log.info("Received %s, canceling jobs and exiting.", signal.Signals(signum).name)
     schedule.clear()
     exit()
 

--- a/traktarr.py
+++ b/traktarr.py
@@ -185,14 +185,15 @@ def shows(list_type, add_limit=0, add_delay=2.5, genre=None, folder=None, no_sea
           authenticate_user=None):
     from media.sonarr import Sonarr
     from media.trakt import Trakt
+    from helpers import misc as misc_helper
     from helpers import sonarr as sonarr_helper
     from helpers import trakt as trakt_helper
 
     added_shows = 0
 
     # remove genre from shows blacklisted_genres if supplied
-    if genre and genre in cfg.filters.shows.blacklisted_genres:
-        cfg['filters']['shows']['blacklisted_genres'].remove(genre)
+    if genre:
+        misc_helper.unblacklist_genres(genre, cfg['filters']['shows']['blacklisted_genres'])
 
     # replace sonarr root_folder if folder is supplied
     if folder:
@@ -212,11 +213,11 @@ def shows(list_type, add_limit=0, add_delay=2.5, genre=None, folder=None, no_sea
 
     # get trakt series list
     if list_type.lower() == 'anticipated':
-        trakt_objects_list = trakt.get_anticipated_shows()
+        trakt_objects_list = trakt.get_anticipated_shows(genres=genre, languages=cfg.filters.shows.allowed_languages)
     elif list_type.lower() == 'trending':
-        trakt_objects_list = trakt.get_trending_shows()
+        trakt_objects_list = trakt.get_trending_shows(genres=genre, languages=cfg.filters.shows.allowed_languages)
     elif list_type.lower() == 'popular':
-        trakt_objects_list = trakt.get_popular_shows()
+        trakt_objects_list = trakt.get_popular_shows(genres=genre, languages=cfg.filters.shows.allowed_languages)
     elif list_type.lower() == 'watchlist':
         trakt_objects_list = trakt.get_watchlist_shows(authenticate_user)
     else:
@@ -254,8 +255,8 @@ def shows(list_type, add_limit=0, add_delay=2.5, genre=None, folder=None, no_sea
     for series in sorted_series_list:
         try:
             # check if genre matches genre supplied via argument
-            if genre and genre.lower() not in series['show']['genres']:
-                log.debug("Skipping: %s because it was not from %s genre", series['show']['title'], genre.lower())
+            if genre and not misc_helper.allowed_genres(genre, 'show', series):
+                log.debug("Skipping: %s because it was not from %s genre(s)", series['show']['title'], genre.lower())
                 continue
 
             # check if series passes out blacklist criteria inspection
@@ -361,14 +362,15 @@ def movies(list_type, add_limit=0, add_delay=2.5, genre=None, folder=None, no_se
            authenticate_user=None):
     from media.radarr import Radarr
     from media.trakt import Trakt
+    from helpers import misc as misc_helper
     from helpers import radarr as radarr_helper
     from helpers import trakt as trakt_helper
 
     added_movies = 0
 
     # remove genre from movies blacklisted_genres if supplied
-    if genre and genre in cfg.filters.movies.blacklisted_genres:
-        cfg['filters']['movies']['blacklisted_genres'].remove(genre)
+    if genre:
+        misc_helper.unblacklist_genres(genre, cfg['filters']['movies']['blacklisted_genres'])
 
     # replace radarr root_folder if folder is supplied
     if folder:
@@ -387,11 +389,11 @@ def movies(list_type, add_limit=0, add_delay=2.5, genre=None, folder=None, no_se
 
     # get trakt movies list
     if list_type.lower() == 'anticipated':
-        trakt_objects_list = trakt.get_anticipated_movies()
+        trakt_objects_list = trakt.get_anticipated_movies(genres=genre, languages=cfg.filters.movies.allowed_languages)
     elif list_type.lower() == 'trending':
-        trakt_objects_list = trakt.get_trending_movies()
+        trakt_objects_list = trakt.get_trending_movies(genres=genre, languages=cfg.filters.movies.allowed_languages)
     elif list_type.lower() == 'popular':
-        trakt_objects_list = trakt.get_popular_movies()
+        trakt_objects_list = trakt.get_popular_movies(genres=genre, languages=cfg.filters.movies.allowed_languages)
     elif list_type.lower() == 'boxoffice':
         trakt_objects_list = trakt.get_boxoffice_movies()
     elif list_type.lower() == 'watchlist':
@@ -431,8 +433,8 @@ def movies(list_type, add_limit=0, add_delay=2.5, genre=None, folder=None, no_se
     for movie in sorted_movies_list:
         try:
             # check if genre matches genre supplied via argument
-            if genre and genre.lower() not in movie['movie']['genres']:
-                log.debug("Skipping: %s because it was not from %s genre", movie['movie']['title'], genre.lower())
+            if genre and not misc_helper.allowed_genres(genre, 'movie', movie):
+                log.debug("Skipping: %s because it was not from %s genre(s)", movie['movie']['title'], genre.lower())
                 continue
 
             # check if movie passes out blacklist criteria inspection


### PR DESCRIPTION
Option to ignore blacklist (config supports it too in auto mode) when processing list by @mitchellklijs 

Added priority option to pushover notification agent by @mitchellklijs 
Run mode scheduler tweaks by @horjulf 

Genre option now requests these genre(s) from trakt, thus reducing list sizes / more targetted results. Also supports multiple genres, e.g. science-fiction,action,horror,thriller.

Added --sort (-s) option to sort the results before processing (supports: votes, rating, release, defaults to votes like before).

Added list types watched and played, these are the most watched/played lists by trakt, supports weekly, monthly, yearly, all types, defaults to weekly, can be specified as e.g. traktarr movies -t watched_monthly ....
