### PR TITLE
Develop

### DIFF
--- a/media/pvr.py
+++ b/media/pvr.py
@@ -27,7 +27,8 @@ class PVR(ABC):
             req = requests.get(
                 os.path.join(misc_str.ensure_endswith(self.server_url, "/"), 'api/system/status'),
                 headers=self.headers,
-                timeout=60
+                timeout=60,
+                allow_redirects=False
             )
             log.debug("Request Response: %d", req.status_code)
 
@@ -49,7 +50,8 @@ class PVR(ABC):
             req = requests.get(
                 os.path.join(misc_str.ensure_endswith(self.server_url, "/"), endpoint),
                 headers=self.headers,
-                timeout=60
+                timeout=60,
+                allow_redirects=False
             )
             log.debug("Request URL: %s", req.url)
             log.debug("Request Response: %d", req.status_code)
@@ -71,7 +73,8 @@ class PVR(ABC):
             req = requests.get(
                 os.path.join(misc_str.ensure_endswith(self.server_url, "/"), 'api/profile'),
                 headers=self.headers,
-                timeout=60
+                timeout=60,
+                allow_redirects=False
             )
             log.debug("Request URL: %s", req.url)
             log.debug("Request Response: %d", req.status_code)
@@ -111,7 +114,8 @@ class PVR(ABC):
                 os.path.join(misc_str.ensure_endswith(self.server_url, "/"), endpoint),
                 headers=self.headers,
                 json=payload,
-                timeout=60
+                timeout=60,
+                allow_redirects=False
             )
             log.debug("Request URL: %s", req.url)
             log.debug("Request Payload: %s", payload)

--- a/media/sonarr.py
+++ b/media/sonarr.py
@@ -23,7 +23,8 @@ class Sonarr(PVR):
             req = requests.get(
                 os.path.join(misc_str.ensure_endswith(self.server_url, "/"), 'api/tag'),
                 headers=self.headers,
-                timeout=60
+                timeout=60,
+                allow_redirects=False
             )
             log.debug("Request URL: %s", req.url)
             log.debug("Request Response: %d", req.status_code)

--- a/traktarr.py
+++ b/traktarr.py
@@ -17,7 +17,7 @@ notify = None
 
 # Click
 @click.group(help='Add new shows & movies to Sonarr/Radarr from Trakt.')
-@click.version_option('1.2.2', prog_name='traktarr')
+@click.version_option('1.2.3', prog_name='traktarr')
 @click.option(
     '--config',
     envvar='TRAKTARR_CONFIG',


### PR DESCRIPTION
Dont allow redirects for sonarr/radarr requests, this should fail api checks when the url is not correct (e.g. missing base name set in sonarr or radarr)