### PR TITLE
add tagmovies: tag plex films with collections from Trakt

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,11 @@ You can repeat this process for as many users as you like.
     },
     "verbose": true
   },
+  "plex": {
+    "url": "http://localhost:32400"
+    "token": "",
+    "movies_library": "Movies",
+  },
   "radarr": {
     "api_key": "",
     "profile": "HD-1080p",
@@ -728,6 +733,23 @@ Trakt Authentication info:
 
 `client_secret` - Fill in your Trakt Secret key (_Client Scret_)
 
+## Plex
+
+Plex authentication info:
+
+```json
+"plex": {
+  "movies_library": "",
+  "token": "",
+  "url": ""
+}
+```
+
+`movies_library` - The name of the movies library in Plex e.g, `Movies`
+
+`token` - Your plex access token.
+
+`url` - Url to your plex server e.g., `http://localhost:32400`
 
 # Usage
 
@@ -901,6 +923,36 @@ Options:
   --help                    Show this message and exit.
 ```
 
+
+## Plex Collections
+
+Use this command to tag Plex movies with a collection name based on a Trakt
+list.
+
+
+```
+traktarr tagmovies --help
+```
+
+
+```
+Usage: traktarr tagmovies [OPTIONS]
+
+  Tags Plex movies with a collection named from a Trakt list.
+
+Options:
+  -t, --list-type TEXT      Trakt list to process. For example, anticipated,
+                            trending, popular, boxoffice, watchlist or any URL
+                            to a list  [required]
+  -n, --name TEXT           Use this name as the collection name instead of
+                            the list name
+  --notifications           Send notifications.
+  --authenticate-user TEXT  Specify which user to authenticate with to
+                            retrieve Trakt lists. Default: first user in the
+                            config.
+  --help                    Show this message and exit.
+```
+
 ## Examples (Manual)
 
 - Add the movie "Black Panther (2018)":
@@ -943,4 +995,10 @@ Options:
 
   ```
   traktarr movies -t https://trakt.tv/users/user1/lists/private-movies-list --authenticate-user=user1
+  ```
+
+- Tag all plex movies with the collection "James Bond Series"
+
+  ```
+  traktarr tagmovies -t "https://trakt.tv/users/danio1972/lists/james-bond-series"
   ```

--- a/helpers/plex.py
+++ b/helpers/plex.py
@@ -1,0 +1,58 @@
+from helpers import str as misc_str
+from misc.log import logger
+
+log = logger.get_logger(__name__)
+
+
+def plex_movies_to_imdb_dict(plex_movies):
+    """
+    Given a list of plex movies, returns a dict where the key is the imdb id
+    and the value is the plex movie object
+    """
+    imdb = {}
+    try:
+        for m in plex_movies:
+            if 'imdb://' in m.guid:
+                imdb_id = m.guid.split('imdb://')[1].split('?')[0]
+            elif 'themoviedb://' in m.guid:
+                # TODO if the user uses the movie db metadata agent
+                # we will need to special case that, and lookup the imdb id
+                log.warn("SKIPPING tmdb ids not supported: s %s ",  m.name)
+                imdb_id = None
+            else:
+                imdb_id = None
+            imdb[imdb_id] = m
+        return imdb
+    except Exception as e:
+        log.exception("Exception processing Radarr movies to TMDB dict: %s", e)
+    return None
+
+
+def match_plex_to_trakt_movies(plex_movies, trakt_movies):
+    """
+    Given a list of plex movies and trakt movies, returns a list containing
+    only the plex movies that exist in the trakt list. Matching is done via
+    imdb id.
+    """
+    if not plex_movies or not trakt_movies:
+        log.error("Inappropriate parameters were supplied")
+        return None
+
+    try:
+        plex_by_imdbs = plex_movies_to_imdb_dict(plex_movies)
+        if not plex_by_imdbs:
+            return None
+        trakt_imdbs = [m['movie']['ids']['imdb'] for m in trakt_movies]
+        matched_movies = [plex_by_imdbs[imdb]
+                          for imdb in trakt_imdbs if imdb in plex_by_imdbs]
+        log.info("Matched %d Plex to %d Trakt movies",
+                 len(plex_movies), len(matched_movies))
+        return matched_movies
+    except Exception as e:
+        log.exception("Exception matching Plex to Trakt list: %s", e)
+    return None
+
+
+def is_movie_in_collection(movie, col_name):
+    return any(col.tag == col_name for col in movie.collections)
+

--- a/media/plex.py
+++ b/media/plex.py
@@ -1,0 +1,49 @@
+import backoff
+import requests
+from plexapi.server import PlexServer
+
+from helpers.misc import backoff_handler, dict_merge
+from helpers.trakt import extract_list_user_and_key_from_url
+from misc.log import logger
+
+log = logger.get_logger(__name__)
+
+
+class Plex:
+
+    def __init__(self, cfg):
+        self.cfg = cfg
+
+    def _get_library(self):
+        plex = PlexServer(self.cfg.plex.url, self.cfg.plex.token)
+        movie_library = plex.library.section(self.cfg.plex.movies_library)
+        return movie_library
+
+    @backoff.on_predicate(backoff.expo, lambda x: x is None, max_tries=4, on_backoff=backoff_handler)
+    def get_movies(self):
+        movie_library = self._get_library()
+        all_movies = movie_library.all()
+        return all_movies
+
+    @backoff.on_predicate(backoff.expo, lambda x: x is None, max_tries=4, on_backoff=backoff_handler)
+    def add_collection(self,  rating_key, collection_name):
+        log.debug("Adding collection %s to %s", collection_name, rating_key)
+        movie_library = self._get_library()
+        library_key = movie_library.key
+        params = {
+                  "type": 1,
+                  "id": rating_key,
+                  "collection[0].tag.tag": collection_name,
+                  "collection.locked": 1
+                  }
+        headers = {"X-Plex-Token": self.cfg.plex.token}
+
+        url = "{base_url}/library/sections/{library}/all".format(
+                base_url=self.cfg.plex.url,
+                library=library_key)
+
+        r = requests.put(url, headers=headers, params=params)
+        if r.status_code == 200:
+            return True
+        return None
+

--- a/misc/config.py
+++ b/misc/config.py
@@ -41,6 +41,11 @@ class Config(object, metaclass=Singleton):
             'client_id': '',
             'client_secret': ''
         },
+        'plex': {
+            'url': 'http://localhost:32400',
+            'token': '',
+            'movies_library': 'Movies'
+        },
         'sonarr': {
             'url': 'http://localhost:8989/',
             'api_key': '',

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ schedule==0.5.0
 attrdict==2.0.0
 click==6.7
 requests~=2.18.4
+plexapi==3.0.6


### PR DESCRIPTION
Add collection tags to plex movies based on a Trakt list


Use this command to tag Plex movies with a collection name based on a Trakt
list.


```
traktarr tagmovies --help
```


```
Usage: traktarr tagmovies [OPTIONS]

  Tags Plex movies with a collection named from a Trakt list.

Options:
  -t, --list-type TEXT      Trakt list to process. For example, anticipated,
                            trending, popular, boxoffice, watchlist or any URL
                            to a list  [required]
  -n, --name TEXT           Use this name as the collection name instead of
                            the list name
  --notifications           Send notifications.
  --authenticate-user TEXT  Specify which user to authenticate with to
                            retrieve Trakt lists. Default: first user in the
                            config.
  --help                    Show this message and exit.
```

**Example**
- Tag all plex movies with the collection "James Bond Series"

  ```
  traktarr tagmovies -t "https://trakt.tv/users/danio1972/lists/james-bond-series"
  ```

@l3uddz this is just the manual command, haven't added the automatic watching of the lists yet.

What do you think?


---

### TODO

- [ ] make the movie library used a run-time flag (default to one in config)