### PR TITLE
Only send notifications if verbose or adding more than 0 from trakt

### DIFF
--- a/traktarr.py
+++ b/traktarr.py
@@ -335,7 +335,7 @@ def shows(list_type, add_limit=0, add_delay=2.5, sort='votes', genre=None, folde
     log.info("Added %d new show(s) to Sonarr", added_shows)
 
     # send notification
-    if notifications:
+    if notifications and (cfg.notifications.verbose or added_shows > 0):
         notify.send(message="Added %d shows from Trakt's %s list" % (added_shows, list_type))
 
     return added_shows
@@ -543,7 +543,7 @@ def movies(list_type, add_limit=0, add_delay=2.5, sort='votes', genre=None, fold
     log.info("Added %d new movie(s) to Radarr", added_movies)
 
     # send notification
-    if notifications:
+    if notifications and (cfg.notifications.verbose or added_movies > 0):
         notify.send(message="Added %d movies from Trakt's %s list" % (added_movies, list_type))
 
     return added_movies
@@ -683,7 +683,7 @@ def automatic_shows(add_delay=2.5, sort='votes', no_search=False, notifications=
 
         log.info("Finished, added %d shows total to Sonarr!", total_shows_added)
         # send notification
-        if notifications:
+        if notifications and (cfg.notifications.verbose or total_shows_added > 0):
             notify.send(message="Added %d shows total to Sonarr!" % total_shows_added)
 
     except Exception:
@@ -772,7 +772,7 @@ def automatic_movies(add_delay=2.5, sort='votes', no_search=False, notifications
 
         log.info("Finished, added %d movies total to Radarr!", total_movies_added)
         # send notification
-        if notifications:
+        if notifications and (cfg.notifications.verbose or total_movies_added > 0):
             notify.send(message="Added %d movies total to Radarr!" % total_movies_added)
 
     except Exception:


### PR DESCRIPTION
When notification output isn't verbose prevent sending out a notification to slack/pushover if nothing has been added from trakt.