### PR TITLE
cfg.trakt.limit_list_results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ __pycache__/
 *.log*
 
 # databases
-/cache.db
+/*.db
 
 # configs
 *.cfg

--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ Private lists can be added in two ways:
    },
    ```
 
-2. If there are multiple authenticated users you want to fetch the lists from, you'll need to specify the username under `authenticate_as`.
+2. If there are multiple authenticated users you want to fetch the lists from, you'll need to specify the username under `authenticate_user`.
 
    _Note: The user should have access to the list (either own the list or a list that was shared to them by a friend)._
 
@@ -492,7 +492,7 @@ Private lists can be added in two ways:
      "movies": {
        "lists": {
            "https://trakt.tv/users/user/lists/my-private-movies-list": {
-               "authenticate_as": "user2",
+               "authenticate_user": "user2",
                "limit": 10
            }
        }
@@ -500,7 +500,7 @@ Private lists can be added in two ways:
      "shows": {
        "lists": {
            "https://trakt.tv/users/user/lists/my-private-shows-list": {
-               "authenticate_as": "user2",
+               "authenticate_user": "user2",
                "limit": 10
            }
        }

--- a/README.md
+++ b/README.md
@@ -508,6 +508,98 @@ Private lists can be added in two ways:
    },
    ```
 
+### Limited Results Lists
+
+These settings are only needed if you plan to limit Trakt results. You define a dictionary where you normally would a value, and use 'add_limit' to send the amount of movies\shows you want to add to Radarr\Sonarr from the results returned, and results_limit to send the amount you want to limit your results to. Below is an example of each list type and how to limit the results to 1.
+
+```json
+  "automatic": {
+    "movies": {
+      "interval": 1,
+      "anticipated": {
+        "add_limit": 1,
+        "results_limit": 1
+      },
+      "boxoffice": {
+        "add_limit": 1,
+        "results_limit": 1
+	  },
+      "played": {
+        "add_limit": 1,
+        "results_limit": 1
+      },
+      "popular": {
+        "add_limit": 1,
+        "results_limit": 1
+	  },
+      "recommended": {
+        "add_limit": 1,
+        "results_limit": 1
+      },
+      "trending": {
+        "add_limit": 1,
+        "results_limit": 1
+	  },
+      "watched": {
+        "add_limit": 1,
+        "results_limit": 1
+      },
+      "watchlist": {
+        "User1": {
+		"add_limit": 1,
+        "results_limit": 1
+		}
+      },
+      "lists": {
+		"https://trakt.tv/users/asterlea/lists/pixar": {
+		"authenticate_user": "User1",
+        "add_limit": 1,
+        "results_limit": 1
+      }
+    }
+	},
+    "shows": {
+      "interval": 1,
+      "anticipated": {
+        "add_limit": 1,
+        "results_limit": 1
+      },
+      "played": {
+        "add_limit": 1,
+        "results_limit": 1
+      },
+      "popular": {
+        "add_limit": 1,
+        "results_limit": 1
+      },
+      "recommended": {
+        "add_limit": 1,
+        "results_limit": 1
+      },
+      "trending": {
+        "add_limit": 1,
+        "results_limit": 1
+      },
+      "watched": {
+        "add_limit": 1,
+        "results_limit": 1
+      },
+      "watchlist": {
+        "User1": {
+		"add_limit": 1,
+        "results_limit": 1
+		}
+      },
+      "lists": {
+		"https://trakt.tv/users/claireaa/lists/top-100-tv-shows-of-all-time-ign": {
+		"authenticate_user": "User1",
+        "add_limit": 1,
+        "results_limit": 1
+      }
+    }
+    }
+  },
+  ```
 
 ## Filters
 

--- a/config.json.sample
+++ b/config.json.sample
@@ -59,7 +59,7 @@
         "fox sports",
         "yahoo!"
       ],
-      "disabled_for": [],
+      "disabled_for": []
     },
     "movies": {
       "allowed_countries": [

--- a/config.json.sample
+++ b/config.json.sample
@@ -108,6 +108,7 @@
   },
   "trakt": {
     "client_id": "",
-    "client_secret": ""
+    "client_secret": "",
+    "limit_list_results": "false"
   }
 }

--- a/config.json.sample
+++ b/config.json.sample
@@ -108,7 +108,6 @@
   },
   "trakt": {
     "client_id": "",
-    "client_secret": "",
-    "limit_list_results": "false"
+    "client_secret": ""
   }
 }

--- a/misc/config.py
+++ b/misc/config.py
@@ -39,8 +39,7 @@ class Config(object, metaclass=Singleton):
         },
         'trakt': {
             'client_id': '',
-            'client_secret': '',
-            'limit_list_results': 'false'
+            'client_secret': ''
         },
         'sonarr': {
             'api_key': '',

--- a/misc/config.py
+++ b/misc/config.py
@@ -39,7 +39,8 @@ class Config(object, metaclass=Singleton):
         },
         'trakt': {
             'client_id': '',
-            'client_secret': ''
+            'client_secret': '',
+            'limit_list_results': 'false'
         },
         'sonarr': {
             'api_key': '',

--- a/traktarr.py
+++ b/traktarr.py
@@ -258,13 +258,6 @@ def shows(list_type, add_limit=0, add_delay=2.5, sort='votes', genre=None, folde
         return None
     else:
         log.info("Retrieved Trakt %s shows list, shows found: %d", list_type, len(trakt_objects_list))
-        
-        if cfg.trakt.limit_list_results == "true":
-            limited_trakt_objects_list = []
-            for x in range(0,add_limit):
-                limited_trakt_objects_list.append(trakt_objects_list[x])
-            trakt_objects_list = limited_trakt_objects_list
-            log.info("Limited Trakt %s movies List, movies left: %d", list_type, len(limited_trakt_objects_list))
 
     # set remove_rejected_recommended to False if this is not the recommended list
     if list_type.lower() != 'recommended':
@@ -506,13 +499,6 @@ def movies(list_type, add_limit=0, add_delay=2.5, sort='votes', rating=None, gen
         return None
     else:
         log.info("Retrieved Trakt %s movies list, movies found: %d", list_type, len(trakt_objects_list))
-        
-        if cfg.trakt.limit_list_results == "true":
-            limited_trakt_objects_list = []
-            for x in range(0,add_limit):
-                limited_trakt_objects_list.append(trakt_objects_list[x])
-            trakt_objects_list = limited_trakt_objects_list
-            log.info("Limited Trakt %s movies List, movies left: %d", list_type, len(limited_trakt_objects_list))
 
     # set remove_rejected_recommended to False if this is not the recommended list
     if list_type.lower() != 'recommended':

--- a/traktarr.py
+++ b/traktarr.py
@@ -258,6 +258,13 @@ def shows(list_type, add_limit=0, add_delay=2.5, sort='votes', genre=None, folde
         return None
     else:
         log.info("Retrieved Trakt %s shows list, shows found: %d", list_type, len(trakt_objects_list))
+        
+        if cfg.trakt.limit_list_results == "true":
+            limited_trakt_objects_list = []
+            for x in range(0,add_limit):
+                limited_trakt_objects_list.append(trakt_objects_list[x])
+            trakt_objects_list = limited_trakt_objects_list
+            log.info("Limited Trakt %s movies List, movies left: %d", list_type, len(limited_trakt_objects_list))
 
     # set remove_rejected_recommended to False if this is not the recommended list
     if list_type.lower() != 'recommended':
@@ -499,6 +506,13 @@ def movies(list_type, add_limit=0, add_delay=2.5, sort='votes', rating=None, gen
         return None
     else:
         log.info("Retrieved Trakt %s movies list, movies found: %d", list_type, len(trakt_objects_list))
+        
+        if cfg.trakt.limit_list_results == "true":
+            limited_trakt_objects_list = []
+            for x in range(0,add_limit):
+                limited_trakt_objects_list.append(trakt_objects_list[x])
+            trakt_objects_list = limited_trakt_objects_list
+            log.info("Limited Trakt %s movies List, movies left: %d", list_type, len(limited_trakt_objects_list))
 
     # set remove_rejected_recommended to False if this is not the recommended list
     if list_type.lower() != 'recommended':


### PR DESCRIPTION
Added a few lines to add the ability to limit Trakt list results. Added a flag named 'cfg.trakt.limit_list_results' to the config to enable. With this change, it functions much more as I suspected. I believe it is a worthwhile addition to Traktarr. I will admit that it could probably be done in a more thorough way, but this works for me in the meantime.