### PR TITLE
Radarr: Change year to integer

### DIFF
--- a/media/radarr.py
+++ b/media/radarr.py
@@ -31,7 +31,7 @@ class Radarr(PVR):
 
         payload = dict_merge(payload, {
             'tmdbId': movie_tmdb_id,
-            'year': movie_year,
+            'year': int(movie_year),
             'minimumAvailability': minimum_availability,
             'addOptions': {
                 'searchForMovie': search_missing


### PR DESCRIPTION
Due to recent Radarr change, Radarr now cares whether year is passed as a string or integer.

https://github.com/Radarr/Radarr/commit/f03dfda2f0be40d18d0e0bc51e083cb1df81c834

Thanks to @saltydk for the assist on this and @ta264 for providing guidance

Fixes #144 