### PR TITLE
Fix formatting on disabled for check

### DIFF
--- a/traktarr.py
+++ b/traktarr.py
@@ -1349,7 +1349,7 @@ def automatic_shows(
 
                     local_ignore_blacklist = ignore_blacklist
 
-                    if "watchlist:%s".format(authenticate_user) in cfg.filters.shows.disabled_for:
+                    if "watchlist:{}".format(authenticate_user) in cfg.filters.shows.disabled_for:
                         local_ignore_blacklist = True
 
                     # run shows
@@ -1384,7 +1384,7 @@ def automatic_shows(
 
                     local_ignore_blacklist = ignore_blacklist
 
-                    if "list:%s".format(list_) in cfg.filters.shows.disabled_for:
+                    if "list:{}".format(list_) in cfg.filters.shows.disabled_for:
                         local_ignore_blacklist = True
 
                     # run shows
@@ -1483,7 +1483,7 @@ def automatic_movies(
 
                     local_ignore_blacklist = ignore_blacklist
 
-                    if "watchlist:%s".format(authenticate_user) in cfg.filters.movies.disabled_for:
+                    if "watchlist:{}".format(authenticate_user) in cfg.filters.movies.disabled_for:
                         local_ignore_blacklist = True
 
                     # run movies
@@ -1519,7 +1519,7 @@ def automatic_movies(
 
                     local_ignore_blacklist = ignore_blacklist
 
-                    if "list:%s".format(list_) in cfg.filters.movies.disabled_for:
+                    if "list:{}".format(list_) in cfg.filters.movies.disabled_for:
                         local_ignore_blacklist = True
 
                     # run shows


### PR DESCRIPTION
This PR fixes the `disabled_for` config option not working correctly for lists.

```
log.info("TEST: %s %s %s %s", "list:%s".format(list_), "list:{}".format(list_), list_, cfg.filters.shows.disabled_for)
```

Returns

```
2022-04-22 12:03:27,368 - INFO       - Traktarr                            - automatic_shows                     - FORMAT TEST: list:%s list:https://trakt.tv/users/sjdaws/lists/tv https://trakt.tv/users/sjdaws/lists/tv ('list:https://trakt.tv/users/sjdaws/lists/tv',)
```

