### PR TITLE
Fix traktarr.py for user watchlists in disabled_for

### DIFF
--- a/traktarr.py
+++ b/traktarr.py
@@ -1349,7 +1349,7 @@ def automatic_shows(
 
                     local_ignore_blacklist = ignore_blacklist
 
-                    if "watchlist:%s".format(authenticate_user) in cfg.filters.shows.disabled_for:
+                    if "watchlist:{}".format(authenticate_user) in cfg.filters.shows.disabled_for:
                         local_ignore_blacklist = True
 
                     # run shows
@@ -1483,7 +1483,7 @@ def automatic_movies(
 
                     local_ignore_blacklist = ignore_blacklist
 
-                    if "watchlist:%s".format(authenticate_user) in cfg.filters.movies.disabled_for:
+                    if "watchlist:{}".format(authenticate_user) in cfg.filters.movies.disabled_for:
                         local_ignore_blacklist = True
 
                     # run movies


### PR DESCRIPTION
Replacing placeholder for .format(), from "%s" to "{}"